### PR TITLE
fix(signup): preserve query param 'sourceSignup' to user metadata

### DIFF
--- a/apps/web/pages/settings/my-account/profile.tsx
+++ b/apps/web/pages/settings/my-account/profile.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 // eslint-disable-next-line no-restricted-imports
 import { get, pick } from "lodash";
 import { signOut, useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
 import type { BaseSyntheticEvent } from "react";
 import React, { useRef, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
@@ -107,6 +108,10 @@ const ProfileView = () => {
         showToast(t("change_of_email_toast", { email: tempFormValues?.email }), "success");
       } else {
         showToast(t("settings_updated_successfully"), "success");
+      }
+
+      if (res.redirectsTo) {
+        redirect(res.redirectsTo);
       }
 
       setTempFormValues(null);

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -237,6 +237,11 @@ export default function Signup({
 
   const signUp: SubmitHandler<FormValues> = async (_data) => {
     const { cfToken, ...data } = _data;
+    const queryParams = new URLSearchParams(window.location.search);
+    const sourceSignup = queryParams.get("source-signup");
+    if (sourceSignup) {
+      data.sourceSignup = sourceSignup;
+    }
     await fetch("/api/auth/signup", {
       body: JSON.stringify({
         ...data,

--- a/packages/features/auth/signup/handlers/selfHostedHandler.ts
+++ b/packages/features/auth/signup/handlers/selfHostedHandler.ts
@@ -24,7 +24,7 @@ import {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const data = req.body;
-  const { email, password, language, token } = signupSchema.parse(data);
+  const { email, password, language, token, sourceSignup } = signupSchema.parse(data);
 
   const username = slugify(data.username);
   const userEmail = email.toLowerCase();
@@ -104,12 +104,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           },
           emailVerified: new Date(Date.now()),
           identityProvider: IdentityProvider.CAL,
+          metadata: {
+            sourceSignup,
+          },
         },
         create: {
           username: correctedUsername,
           email: userEmail,
           password: { create: { hash: hashedPassword } },
           identityProvider: IdentityProvider.CAL,
+          metadata: {
+            sourceSignup,
+          },
         },
       });
 
@@ -162,12 +168,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         },
         emailVerified: new Date(Date.now()),
         identityProvider: IdentityProvider.CAL,
+        metadata: {
+          sourceSignup,
+        },
       },
       create: {
         username: correctedUsername,
         email: userEmail,
         password: { create: { hash: hashedPassword } },
         identityProvider: IdentityProvider.CAL,
+        metadata: {
+          sourceSignup,
+        },
       },
     });
 

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -344,6 +344,7 @@ export const userMetadata = z
         revertTime: z.string().optional(),
       })
       .optional(),
+    sourceSignup: z.string().optional(),
   })
   .nullable();
 
@@ -677,6 +678,7 @@ export const signupSchema = z.object({
     });
   }),
   language: z.string().optional(),
+  sourceSignup: z.string().optional(),
   token: z.string().optional(),
 });
 

--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -422,6 +422,7 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
     avatarUrl: updatedUser.avatarUrl,
     hasEmailBeenChanged,
     sendEmailVerification: emailVerification && !secondaryEmail?.emailVerified,
+    redirectsTo: userMetadata.sourceSignup === "team" && "/settings/teams/new",
   };
 };
 


### PR DESCRIPTION
## What does this PR do?
persiste signup source to database throughout the signup process to directly show them the team creation flow.

Fixes https://github.com/calcom/cal.com/issues/14807

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Requirement/Documentation

issue description available [here](https://github.com/calcom/cal.com/issues/14807)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How should this be tested?

- follow readme instructions to setup local env
- go to http://localhost:3000/signup?source-signup=team
- create a fake account with any name/email
- run following psql query in DB: `SELECT token FROM "VerificationToken" order by id desc limit 1;`
- copy the result token
- go to http://localhost:3000/api/auth/verify-email?token=[PAST_TOKEN_HERE] (this is to simulate the "Verify your account" email link)
- skip all skippable steps (connect calendars, connect video)
- leave "setup availabilities" values by default
- validate your profile

expected behavior: you should be automatically redirected to http://localhost:3000/settings/teams/new

repeating all previous steps, but without the `?source-signup=team` in the signum url, should redirect user to http://localhost:3000/event-types and not to http://localhost:3000/settings/teams/new

## Checklist

- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
